### PR TITLE
Configurable Historical Load

### DIFF
--- a/dags/collect_tmio.py
+++ b/dags/collect_tmio.py
@@ -1,29 +1,40 @@
 from datetime import datetime
 import json
 from airflow import DAG
+from airflow.models.variable import Variable
 from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import PythonOperator
 from airflow.providers.postgres.operators.postgres import PostgresOperator
 import requests
 
 
+HISTORICAL_LOAD_DAYS = int(Variable.get('HISTORICAL_LOAD_DAYS'))
 
-def scrape_totd_today(ti):
-    url = f"https://trackmania.io/api/totd/0"
-    headers = {'User-Agent' : 'TOTD-Data-Lake-Daily-Load-Dev'}
-    resp = requests.get(url, headers=headers)
-    j = resp.json()
 
-    year, month, day =  j['year'], j['month'], len(j['days'])
-    totd_today = j['days'][-1]
+def scrape_totds(ti):
+    json_data = []
+    months_back = -1
+    while len(json_data) < HISTORICAL_LOAD_DAYS:
+        months_back += 1
+        url = f"https://trackmania.io/api/totd/{months_back}"
+        headers = {'User-Agent' : 'TOTD-Data-Lake-Daily-Load-Dev'}
+        resp = requests.get(url, headers=headers)
+        j = resp.json()
 
-    data = {
-        'year': year,
-        'month': month,
-        'day': day,
-        'json_data' : json.dumps(totd_today)
-    }
-    ti.xcom_push(key= 'tmio_totd_today', value = data)
+        for i,totd in enumerate(reversed(j['days'])):
+            year, month, day =  j['year'], j['month'], len(j['days'])-i
+
+            totd_data = {
+                'year': year,
+                'month': month,
+                'day': day,
+                'json_data' : json.dumps(totd)
+            }
+            json_data.append(totd_data)
+            if len(json_data) == HISTORICAL_LOAD_DAYS:
+                break
+        
+    ti.xcom_push(key= 'tmio_totds', value = json.dumps(json_data))
     
 
 
@@ -38,23 +49,25 @@ with DAG(
     end_task = EmptyOperator(task_id = 'end_task')
 
     # send GET request for today's TOTD
-    _scrape_totd_today = PythonOperator(
-        task_id = 'scrape_totd_today',
-        python_callable = scrape_totd_today,
+    _scrape_totds = PythonOperator(
+        task_id = 'scrape_totds',
+        python_callable = scrape_totds,
     )
 
     # dump TOTD raw data into collection layer
     sql = """
         INSERT INTO collect.tmio (data_year, data_month, data_day, json_data)
-        VALUES (
-            {{ti.xcom_pull(key='tmio_totd_today')['year']}},
-            {{ti.xcom_pull(key='tmio_totd_today')['month']}},
-            {{ti.xcom_pull(key='tmio_totd_today')['day']}},
-            $${{ti.xcom_pull(key='tmio_totd_today')['json_data']}}$$
-        )
-        ON CONFLICT DO NOTHING;
+        SELECT
+            (j->>'year')::INTEGER,
+            (j->>'month')::INTEGER,
+            (j->>'day')::INTEGER,
+            j->>'json_data'
+        FROM JSON_ARRAY_ELEMENTS($${{ti.xcom_pull(key='tmio_totds')}}$$::JSON) AS j
+        ON CONFLICT (data_year, data_month, data_day)
+        DO UPDATE SET
+            json_data = EXCLUDED.json_data;
     """
     _push_to_postgres = PostgresOperator(task_id = 'push_to_postgres', sql=sql, postgres_conn_id='trackmania_postgres', database='trackmania')
 
 
-    start_task >> _scrape_totd_today >> _push_to_postgres >> end_task
+    start_task >> _scrape_totds >> _push_to_postgres >> end_task

--- a/dags/collect_tmio.py
+++ b/dags/collect_tmio.py
@@ -63,9 +63,7 @@ with DAG(
             (j->>'day')::INTEGER,
             j->>'json_data'
         FROM JSON_ARRAY_ELEMENTS($${{ti.xcom_pull(key='tmio_totds')}}$$::JSON) AS j
-        ON CONFLICT (data_year, data_month, data_day)
-        DO UPDATE SET
-            json_data = EXCLUDED.json_data;
+        ON CONFLICT DO NOTHING;
     """
     _push_to_postgres = PostgresOperator(task_id = 'push_to_postgres', sql=sql, postgres_conn_id='trackmania_postgres', database='trackmania')
 

--- a/dags/collect_tmio_enhancements.py
+++ b/dags/collect_tmio_enhancements.py
@@ -1,26 +1,33 @@
 from datetime import datetime
 import json
 from airflow import DAG
+from airflow.models.variable import Variable
 from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import PythonOperator
 from airflow.providers.postgres.operators.postgres import PostgresOperator
 import requests
 
+
+HISTORICAL_LOAD_DAYS = int(Variable.get('HISTORICAL_LOAD_DAYS'))
     
 
-def scrape_leaderboards_today(ti):
-    tmp = ti.xcom_pull(dag_id = ti.dag_id, task_ids = 'get_totd_map_uid')[0]
-    map_uid, leaderboard_uid = tmp[0], tmp[1]
-    url = f"https://trackmania.io/api/leaderboard/{leaderboard_uid}/{map_uid}?offset=0&length=10"
-    headers = {'User-Agent' : 'TOTD-Data-Lake-Daily-Load-Dev'}
-    resp = requests.get(url, headers=headers)
-    totd_today = resp.json()
+def scrape_leaderboards(ti):
+    res = ti.xcom_pull(dag_id = ti.dag_id, task_ids = 'get_totd_map_uids')
+    json_data = []
+    for tmp in res:
+        map_uid, leaderboard_uid = tmp[0], tmp[1]
+        url = f"https://trackmania.io/api/leaderboard/{leaderboard_uid}/{map_uid}?offset=0&length=10"
+        headers = {'User-Agent' : 'TOTD-Data-Lake-Daily-Load-Dev'}
+        resp = requests.get(url, headers=headers)
+        
+        data = {
+            'map_uid' : map_uid,
+            'json_data' : json.dumps(resp.json())
+        }
 
-    data = {
-        'map_uid' : map_uid,
-        'json_data' : json.dumps(totd_today)
-    }
-    ti.xcom_push(key = 'tmio_leaderboards_today', value = data)
+        json_data.append(data)
+
+    ti.xcom_push(key = 'tmio_leaderboards', value = json.dumps(json_data))
 
 
 
@@ -36,29 +43,29 @@ with DAG(
 
 
     # query Postgres for latest TOTD map_uid
-    sql = """
+    sql = f"""
         SELECT map_uid, leaderboard_uid
         FROM CONFORM.TMIO
         ORDER BY totd_year, totd_month, totd_day DESC
-        LIMIT 1;
+        LIMIT {HISTORICAL_LOAD_DAYS};
     """
-    _get_totd_map_uid = PostgresOperator(task_id = 'get_totd_map_uid', sql=sql, postgres_conn_id='trackmania_postgres', database='trackmania')
+    _get_totd_map_uidss = PostgresOperator(task_id = 'get_totd_map_uids', sql=sql, postgres_conn_id='trackmania_postgres', database='trackmania')
 
 
     # send GET request for today's TOTD leaderboards
-    _scrape_leaderboards_today = PythonOperator(
-        task_id = 'scrape_leaderboards_today',
-        python_callable = scrape_leaderboards_today,
+    _scrape_leaderboards = PythonOperator(
+        task_id = 'scrape_leaderboards',
+        python_callable = scrape_leaderboards,
     )
 
 
     # dump leaderboards data into collection layer
     sql = """
         INSERT INTO collect.tmio_leaderboards (map_uid, json_data)
-        VALUES (
-            $${{ti.xcom_pull(key='tmio_leaderboards_today')['map_uid']}}$$,
-            $${{ti.xcom_pull(key='tmio_leaderboards_today')['json_data']}}$$
-        )
+        SELECT
+            j->>'map_uid',
+            j->>'json_data'
+            FROM JSON_ARRAY_ELEMENTS($${{ti.xcom_pull(key='tmio_leaderboards')}}$$::JSON) AS j
         ON CONFLICT (map_uid)
         DO UPDATE SET
             json_data = EXCLUDED.json_data;
@@ -67,4 +74,4 @@ with DAG(
 
 
     # orchestrate tasks
-    start_task >> _get_totd_map_uid >> _scrape_leaderboards_today >> _push_leaderboards_to_postgres >> end_task
+    start_task >> _get_totd_map_uidss >> _scrape_leaderboards >> _push_leaderboards_to_postgres >> end_task

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -53,6 +53,7 @@ x-airflow-common:
     dockerfile: ./dockerfiles/airflow.Dockerfile
   environment:
     &airflow-common-env
+    AIRFLOW_VAR_HISTORICAL_LOAD_DAYS: 10
     AIRFLOW_CONN_TRACKMANIA_POSTGRES: postgres://airflow:airflow@trackmania-postgres/trackmania
     # Core Airflow variables
     AIRFLOW__CORE__EXECUTOR: CeleryExecutor
@@ -62,7 +63,7 @@ x-airflow-common:
     AIRFLOW__CELERY__RESULT_BACKEND: db+postgresql://airflow:airflow@airflow-postgres/airflow
     AIRFLOW__CELERY__BROKER_URL: redis://:@redis:6379/0
     AIRFLOW__CORE__FERNET_KEY: ''
-    AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: 'false'
+    AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: 'true'
     AIRFLOW__CORE__LOAD_EXAMPLES: 'false'
     AIRFLOW__API__AUTH_BACKENDS: 'airflow.api.auth.backend.basic_auth,airflow.api.auth.backend.session'
     _PIP_ADDITIONAL_REQUIREMENTS: ${_PIP_ADDITIONAL_REQUIREMENTS:-}


### PR DESCRIPTION
Modified collection layer DAGs and Airflow Docker image to set a window for historical data load (in days). Tested all conform and consume DAGs to confirm still working as expected with re-ingesting past days' data.

Closes #3 